### PR TITLE
Remove incorrectly set vertical variants

### DIFF
--- a/sources/NotoSansMath.glyphspackage/glyphs/leftanglebracket-math.s20.glyph
+++ b/sources/NotoSansMath.glyphspackage/glyphs/leftanglebracket-math.s20.glyph
@@ -20,24 +20,4 @@ ref = _part.leftanglebracket;
 width = 908;
 }
 );
-userData = {
-com.nagwa.MATHPlugin.extendedShape = 1;
-com.nagwa.MATHPlugin.variants = {
-vVariants = (
-"leftanglebracket-math",
-"leftanglebracket-math.s01",
-"leftanglebracket-math.s02",
-"leftanglebracket-math.s03",
-"leftanglebracket-math.s04",
-"leftanglebracket-math.s05",
-"leftanglebracket-math.s06",
-"leftanglebracket-math.s07",
-"leftanglebracket-math.s08",
-"leftanglebracket-math.s09",
-"leftanglebracket-math.s10",
-"leftanglebracket-math.s11",
-"leftanglebracket-math.s12"
-);
-};
-};
 }

--- a/sources/NotoSansMath.glyphspackage/glyphs/leftanglebracketdot.s20.glyph
+++ b/sources/NotoSansMath.glyphspackage/glyphs/leftanglebracketdot.s20.glyph
@@ -20,24 +20,4 @@ ref = _part.leftanglebracketdot;
 width = 905;
 }
 );
-userData = {
-com.nagwa.MATHPlugin.extendedShape = 1;
-com.nagwa.MATHPlugin.variants = {
-vVariants = (
-leftanglebracketdot,
-leftanglebracketdot.s01,
-leftanglebracketdot.s02,
-leftanglebracketdot.s03,
-leftanglebracketdot.s04,
-leftanglebracketdot.s05,
-leftanglebracketdot.s06,
-leftanglebracketdot.s07,
-leftanglebracketdot.s08,
-leftanglebracketdot.s09,
-leftanglebracketdot.s10,
-leftanglebracketdot.s11,
-leftanglebracketdot.s12
-);
-};
-};
 }

--- a/sources/NotoSansMath.glyphspackage/glyphs/rightanglebracket-math.s20.glyph
+++ b/sources/NotoSansMath.glyphspackage/glyphs/rightanglebracket-math.s20.glyph
@@ -20,24 +20,4 @@ ref = _part.rightanglebracket;
 width = 908;
 }
 );
-userData = {
-com.nagwa.MATHPlugin.extendedShape = 1;
-com.nagwa.MATHPlugin.variants = {
-vVariants = (
-"rightanglebracket-math",
-"rightanglebracket-math.s01",
-"rightanglebracket-math.s02",
-"rightanglebracket-math.s03",
-"rightanglebracket-math.s04",
-"rightanglebracket-math.s05",
-"rightanglebracket-math.s06",
-"rightanglebracket-math.s07",
-"rightanglebracket-math.s08",
-"rightanglebracket-math.s09",
-"rightanglebracket-math.s10",
-"rightanglebracket-math.s11",
-"rightanglebracket-math.s12"
-);
-};
-};
 }

--- a/sources/NotoSansMath.glyphspackage/glyphs/rightanglebracketdot.s20.glyph
+++ b/sources/NotoSansMath.glyphspackage/glyphs/rightanglebracketdot.s20.glyph
@@ -20,24 +20,4 @@ ref = _part.rightanglebracketdot;
 width = 905;
 }
 );
-userData = {
-com.nagwa.MATHPlugin.extendedShape = 1;
-com.nagwa.MATHPlugin.variants = {
-vVariants = (
-rightanglebracketdot,
-rightanglebracketdot.s01,
-rightanglebracketdot.s02,
-rightanglebracketdot.s03,
-rightanglebracketdot.s04,
-rightanglebracketdot.s05,
-rightanglebracketdot.s06,
-rightanglebracketdot.s07,
-rightanglebracketdot.s08,
-rightanglebracketdot.s09,
-rightanglebracketdot.s10,
-rightanglebracketdot.s11,
-rightanglebracketdot.s12
-);
-};
-};
 }


### PR DESCRIPTION
Some variant glyphs had the variants list of the base glyph duplicated in them which is bogus.

Fixes #86.