### PR TITLE
Make sure extender parts of accent assemblies has non-zero end connector

### DIFF
--- a/sources/NotoSansMath.glyphspackage/fontinfo.plist
+++ b/sources/NotoSansMath.glyphspackage/fontinfo.plist
@@ -1,5 +1,5 @@
 {
-.appVersion = "3303";
+.appVersion = "3324";
 .formatVersion = 3;
 classes = (
 {

--- a/sources/NotoSansMath.glyphspackage/glyphs/dbllowlinecomb.glyph
+++ b/sources/NotoSansMath.glyphspackage/glyphs/dbllowlinecomb.glyph
@@ -22,7 +22,7 @@ dbllowlinecomb.s00,
 dbllowlinecomb.s00,
 1,
 417,
-0
+417
 )
 );
 };

--- a/sources/NotoSansMath.glyphspackage/glyphs/dbloverlinecomb.glyph
+++ b/sources/NotoSansMath.glyphspackage/glyphs/dbloverlinecomb.glyph
@@ -28,7 +28,7 @@ dbloverlinecomb.s00,
 dbloverlinecomb.s00,
 1,
 417,
-0
+417
 )
 );
 };

--- a/sources/NotoSansMath.glyphspackage/glyphs/lowlinecomb.glyph
+++ b/sources/NotoSansMath.glyphspackage/glyphs/lowlinecomb.glyph
@@ -22,7 +22,7 @@ lowlinecomb.s00,
 lowlinecomb.s00,
 1,
 417,
-0
+417
 )
 );
 };

--- a/sources/NotoSansMath.glyphspackage/glyphs/overlinecomb.glyph
+++ b/sources/NotoSansMath.glyphspackage/glyphs/overlinecomb.glyph
@@ -27,7 +27,7 @@ overlinecomb.s00,
 overlinecomb.s00,
 1,
 417,
-0
+417
 )
 );
 };

--- a/sources/NotoSansMath.glyphspackage/order.plist
+++ b/sources/NotoSansMath.glyphspackage/order.plist
@@ -5102,5 +5102,6 @@ _contour6.integral,
 _intersection.integral,
 _quaternion.integral,
 _slash.integral,
-_stroke.integral
+_stroke.integral,
+VS1
 )


### PR DESCRIPTION
Fixes https://github.com/notofonts/math/issues/94